### PR TITLE
Makefileのinitからrunを削除した

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -7,7 +7,7 @@ GOGET=$(GOCMD) get
 BINARY_NAME=gobinary
 
 .PHONY: init
-init: clean deps test precommit build run
+init: clean deps test precommit build
 
 .PHONY: all
 all: test precommit build run


### PR DESCRIPTION
https://github.com/SekiguchiKai/clean-architecture-with-go/issues/53 に対応した。